### PR TITLE
feat: add function to refresh authorization token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 deno.json
+deno.lock
 development.ts

--- a/src/authentication/refreshAuthorizationToken.ts
+++ b/src/authentication/refreshAuthorizationToken.ts
@@ -1,0 +1,85 @@
+// Data
+import { authorizationHeaders } from "../../data/authentication/authenticationHeaders.ts";
+import {
+  AUTHORIZATION_TOKEN_ENDPOINT,
+  BASE_URL,
+} from "../../data/base/urls.ts";
+// Helper functions
+import { nowTimestamp } from "../../services/nowTimestamp.ts";
+// Types
+import type { AuthenticatedResponse } from "../../types/authentication/AuthenticatedResponse_type.ts";
+import type { AuthenticationData } from "../../types/authentication/AuthenticationData_type.ts";
+
+/**
+ * Updates the Authentication Token to allow new requests to be executed.
+ *
+ * @param token `AuthenticationData` object provided by a successful authentication with `getAuthorizationToken()` or `authenticateWithNpsso()`.
+ * @returns A new `AuthenticationData` object with data required to request further data from other endpoints.
+ */
+export async function refreshAuthorizationToken(token: AuthenticationData) {
+  // Throw error if invalid parameter or refreshToken was provided
+  if (token === undefined || typeof token.refreshToken !== "string") {
+    throw new Error(
+      'No valid "refreshToken" passed, impossible to refresh accessToken without one.',
+    );
+  }
+
+  const now = nowTimestamp();
+
+  // Throw error if no valid refreshToken timestamp is provided
+  if (typeof token.refreshTokenExpirationEpoch !== "number") {
+    throw new Error(
+      "Token doesn't provide a numerical 'refreshTokenExpirationEpoch', required to check if the refreshToken is within refresh Date range.",
+    );
+  }
+
+  // Throw error if the refreshToken timestamp expired
+  if (now > token.refreshTokenExpirationEpoch) {
+    throw new Error(
+      'The "refreshToken" is too old to be refreshed. Please login again using a new NPSSO.',
+    );
+  }
+
+  const authorizationRequestBody = new URLSearchParams({
+    "refresh_token": token.refreshToken,
+    "grant_type": "refresh_token",
+    "token_format": "jwt",
+    "scope": "psn:mobile.v2.core psn:clientapp",
+  }).toString();
+
+  const authorizationRequestOptions: RequestInit = {
+    "method": "POST",
+    "headers": authorizationHeaders,
+    "body": authorizationRequestBody,
+  };
+
+  const res = await fetch(
+    BASE_URL + AUTHORIZATION_TOKEN_ENDPOINT,
+    authorizationRequestOptions,
+  );
+
+  if (res.status !== 200) {
+    await res.body?.cancel(); // Dispose the body to avoid memory leaks
+    throw new Error(
+      `Authentication failed! Failed to use Refresh Token to retrieve an updated Authentication Token. Status code: ${res.status.toString()}, Error message: ${res.statusText}`,
+    );
+  }
+  const authenticationResponse: AuthenticatedResponse = await res.json();
+
+  const { access_token, expires_in, refresh_token, refresh_token_expires_in } =
+    authenticationResponse;
+
+  const authentication: AuthenticationData = {
+    accessToken: access_token,
+    tokenExpirationEpoch: now + expires_in * 1000,
+    humanReadableTokenExpiration: new Date(now + expires_in * 1000)
+      .toISOString(),
+    refreshToken: refresh_token,
+    refreshTokenExpirationEpoch: now + refresh_token_expires_in * 1000,
+    humanReadableRefreshTokenExpiration: new Date(
+      now + refresh_token_expires_in * 1000,
+    ).toISOString(),
+  };
+
+  return authentication;
+}

--- a/test.ts
+++ b/test.ts
@@ -9,6 +9,7 @@ import { authenticateWithNpsso } from "./src/authentication/authenticateWithNpss
 import { AuthenticationData } from "./types/authentication/AuthenticationData_type.ts";
 import { getAccessCode } from "./src/authentication/getAccessCode.ts";
 import { getAuthorizationToken } from "./src/authentication/getAuthorizationToken.ts";
+import { refreshAuthorizationToken } from "./src/authentication/refreshAuthorizationToken.ts";
 
 let NPSSO: string | undefined;
 if (Deno.env.has("RUNNING_AS_GITHUB_ACTION")) {
@@ -22,6 +23,40 @@ let auth: AuthenticationData;
 
 // Tests wether a valid NPSSO is provided and it's possible to authenticate on PSN using it
 Deno.test({ name: "Authenticate using NPSSO" }, async (t) => {
+  // Test if an error is thrown when a bad NPSSO string is passed as parameter of getAccessCode()
+  await t.step(
+    "Fails to get access code when an invalid NPSSO string is passed",
+    async () => {
+      try {
+        await getAccessCode("awfulbadstringnotnpsso");
+        assert(false);
+      } catch (error) {
+        assertIsError(error);
+        assertEquals(
+          error.message,
+          "Malformed Access Code received, this usually happens because a bad NPSSO was provided. Please visit https://ca.account.sony.com/api/v1/ssocookie and double check if you have provided the correct NPSSO.",
+        );
+      }
+    },
+  );
+
+  // Test if an error is thrown when getAuthorizationToken() receives an invalid accessCode string
+  await t.step(
+    "Fails to get an Authorization Token when a bad Access Code is provided",
+    async () => {
+      try {
+        await getAuthorizationToken("verybadaccesscode");
+        assert(false);
+      } catch (error) {
+        assertIsError(error);
+        assertEquals(
+          error.message,
+          "Authentication failed! Failed to use Access Code to retrieve Authentication Token. Status code: 400, Error message: Bad Request",
+        );
+      }
+    },
+  );
+
   // Test if a NPSSO was passed
   await t.step(
     "Check if a valid NPSSO was passed as Enviroment Variable",
@@ -72,38 +107,155 @@ Deno.test({ name: "Authenticate using NPSSO" }, async (t) => {
   });
 });
 
-Deno.test("Authentication workflow throws appropriate errors when bad information is provided", async (t) => {
-  // Test if an error is thrown when a bad NPSSO string is passed to getAccessCode()
+// Tests for refreshing Authentication Tokens
+Deno.test("Refresh Authentication Token using Refresh Token", async (t) => {
+  // Test if refreshAuthorizationToken() throws the correct errors
   await t.step(
-    "Fails to get access code when an invalid NPSSO string is passed",
-    async () => {
-      try {
-        await getAccessCode("awfulbadstringnotnpsso");
-        assert(false);
-      } catch (error) {
-        assertIsError(error);
-        assertEquals(
-          error.message,
-          "Malformed Access Code received, this usually happens because a bad NPSSO was provided. Please visit https://ca.account.sony.com/api/v1/ssocookie and double check if you have provided the correct NPSSO.",
-        );
-      }
+    "Checking if refreshAuthorizationToken() handles all error cases",
+    async (t) => {
+      // Throws error when no token is provided
+      await t.step(
+        "refreshAuthorizationToken() throws error when no token is provided",
+        async () => {
+          try {
+            // @ts-ignore: Not passing arguments on purpose to check for error handling
+            await refreshAuthorizationToken();
+            assert(false);
+          } catch (error) {
+            assertIsError(error);
+            assertEquals(
+              error.message,
+              'No valid "refreshToken" passed, impossible to refresh accessToken without one.',
+            );
+          }
+        },
+      );
+
+      // Throws error when token doesn't have a refreshToken field
+      await t.step(
+        "refreshAuthorizationToken() throws error when refreshToken isn't a string",
+        async () => {
+          try {
+            await refreshAuthorizationToken({
+              ...auth,
+              // @ts-ignore: Removing required property to check for error handling
+              refreshToken: undefined,
+            });
+            assert(false);
+          } catch (error) {
+            assertIsError(error);
+            assertEquals(
+              error.message,
+              'No valid "refreshToken" passed, impossible to refresh accessToken without one.',
+            );
+          }
+        },
+      );
+
+      // Throws error when token's refreshTokenExpirationEpoch isn't a number
+      await t.step(
+        "refreshAuthorizationToken() throws error when refreshTokenExpirationEpoch property isn't a number",
+        async () => {
+          try {
+            await refreshAuthorizationToken({
+              ...auth,
+              // @ts-ignore: Removing required property to check for error handling
+              refreshTokenExpirationEpoch: undefined,
+            });
+            assert(false);
+          } catch (error) {
+            assertIsError(error);
+            assertEquals(
+              error.message,
+              "Token doesn't provide a numerical 'refreshTokenExpirationEpoch', required to check if the refreshToken is within refresh Date range.",
+            );
+          }
+        },
+      );
+
+      // Throws error when token's refreshTokenExpirationEpoch has expired
+      await t.step(
+        "refreshAuthorizationToken() throws error when refreshTokenExpirationEpoch is too old to refresh the token",
+        async () => {
+          try {
+            await refreshAuthorizationToken({
+              ...auth,
+              refreshTokenExpirationEpoch: auth.refreshTokenExpirationEpoch -
+                99999999999999,
+            });
+            assert(false);
+          } catch (error) {
+            assertIsError(error);
+            assertEquals(
+              error.message,
+              'The "refreshToken" is too old to be refreshed. Please login again using a new NPSSO.',
+            );
+          }
+        },
+      );
     },
   );
 
-  // Test if an error is thrown when getAuthorizationToken() receives an invalid accessCode string
+  // Test if the token has the correct refreshToken property type
+  await t.step("Test if the refreshToken is a string", () => {
+    assertEquals(typeof auth.refreshToken, "string");
+  });
+
+  // Test if the token has the correct refreshTokenExpirationEpoch property type
+  await t.step("Test if the refreshTokenExpirationEpoch is a number", () => {
+    assertEquals(typeof auth.refreshTokenExpirationEpoch, "number");
+  });
+
+  // Test if the token can still be refreshed
   await t.step(
-    "Fails to get an Authorization Token when a bad Access Code is provided",
-    async () => {
-      try {
-        await getAuthorizationToken("verybadaccesscode");
-        assert(false);
-      } catch (error) {
-        assertIsError(error);
+    "Test if the refreshToken is still valid",
+    () => {
+      assert(auth.refreshTokenExpirationEpoch > Date.now());
+    },
+  );
+
+  // Test if the token would allow us to refresh the authentication status
+  await t.step(
+    "Test if we are able to refresh the authentication token",
+    async (tt) => {
+      const refreshedAuthorization = await refreshAuthorizationToken(auth);
+
+      await tt.step("Refreshed authorization has accessToken", () => {
+        assertEquals(typeof refreshedAuthorization.accessToken, "string");
+      });
+      await tt.step("Refreshed authorization has tokenExpirationEpoch", () => {
         assertEquals(
-          error.message,
-          "Authentication failed! Failed to use Access Code to retrieve Authentication Token. Status code: 400, Error message: Bad Request",
+          typeof refreshedAuthorization.tokenExpirationEpoch,
+          "number",
         );
-      }
+      });
+      await tt.step(
+        "Refreshed authorization has humanReadableTokenExpiration",
+        () => {
+          assertEquals(
+            typeof refreshedAuthorization.humanReadableTokenExpiration,
+            "string",
+          );
+        },
+      );
+      await tt.step("Refreshed authorization has refreshToken", () => {
+        assertEquals(typeof refreshedAuthorization.refreshToken, "string");
+      });
+      await tt.step("Refreshed authorization has tokenExpirationEpoch", () => {
+        assertEquals(
+          typeof refreshedAuthorization.tokenExpirationEpoch,
+          "number",
+        );
+      });
+      await tt.step(
+        "Refreshed authorization has humanReadableRefreshTokenExpiration",
+        () => {
+          assertEquals(
+            typeof refreshedAuthorization.humanReadableRefreshTokenExpiration,
+            "string",
+          );
+        },
+      );
     },
   );
 });


### PR DESCRIPTION
Tokens can be refreshed after being created. This will be done internally and abstracted away from the user.

Additionally, this PR adds tests for this new function and reorganized the tests to nest errors and return a failed test as soon as possible, avoiding unnecessary network requests to PSN if a prior test failed.