### PR TITLE
feat: created Singleton Authentication Manager

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build:

--- a/Contribute.md
+++ b/Contribute.md
@@ -1,0 +1,81 @@
+# Contributing
+
+All contributions are welcome, I want to have this API covering 100% of the
+known endpoints from PSN. You can see most of them listed either
+[Playstation Trophies API Documentation](https://andshrew.github.io/PlayStation-Trophies/#/APIv2?id=_1-retrieve-the-trophy-titles-for-a-user)
+by [andshrew](https://github.com/andshrew) and my Postman Collection.
+
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/14106843-e19286eb-8d3d-4fcf-97eb-abbe368462b5?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D14106843-e19286eb-8d3d-4fcf-97eb-abbe368462b5%26entityType%3Dcollection%26workspaceId%3D74248cb6-445a-40c0-a1b3-e2f39a55bced)
+
+## Test coverage
+
+End-to-end tests are run on every Pull Request. All features are tested
+extensively so that we can try to fix issues before users even need to report
+them.
+
+## Setting up your enviroment for contributing
+
+- Clone this repository.
+- Edit the `.env` file with your own NPSSO code (this is required to run the
+  tests).
+- This repository is written using the Deno runtime, so you are going to need to
+  have that
+  [installed](https://deno.land/manual@v1.35.0/getting_started/installation#download-and-install),
+  the
+  [deno extension installed](https://deno.land/manual@v1.35.0/references/vscode_deno#using-visual-studio-code)
+  on VS Code and
+  [initialize your workspace settings](https://deno.land/manual@v1.35.0/references/vscode_deno#configuring-the-extension).
+  - If you have never used Deno before, worry not because it's a lot like Node,
+    except that is better in every way.
+  - Don't worry if the packages in `test.ts` are showing errors, they are cached
+    automatically on the first run.
+- Create the files below on the root of the project to help you developing
+  faster:
+
+```json
+// deno.json
+{
+  "tasks": {
+    "start": "deno run --allow-net development.ts",
+    "watch": "deno run --allow-net --watch=./development.ts development.ts",
+    "test": "deno test --allow-env --allow-read --allow-net ./test.ts"
+  }
+}
+```
+
+```ts
+// development.ts
+// This is where you are going to work to test your features and import any functions.
+```
+
+Before you start writing any code, run `deno task test` to ensure that your
+setup is working properly. That will install all the packages and run all tests,
+which should all PASS.
+
+Now you can use `deno task start` to run your `development.ts` code and
+`deno task test` to test if everything is still working as before.
+
+### Asking for help
+
+If you have difficulty in understanding the code and would like some help in
+order to contribute, feel free to reach out on Discord (I'm @theyurig there as
+well).
+
+Don't be afraid of being judged, I'm constantly pair programming with junior
+software developers, so it's not a problem if you never wrote a test before or
+used Typescript or just feel overwhelmed, I'll do my best to get you up to speed
+fast.
+
+## How this repository is organized
+
+```
+prizewinner/
+├─ data/                  // Reused files containing static values
+├─ services/              // Utility functions that don't return PSN data
+├─ src/                   // Functions that return PSN data and users will directly use
+│  ├─ authentication/        // Authentication-related functions
+├─ types/                 // Reused files that only contain types, but no data
+├─ mod.ts                 // The starting file that exports all user-facing functions
+├─ test.ts                // All tests live here 
+├─ development.ts ←       // The common starting point for testing and working on features/bugs
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # Prizewinner
 
-A Typescript API with no external dependencies for pulling data from a PSN
-account.
+A zero-dependency API written in pure Typescript for retrieving data from PSN.
+
+## Getting started
+
+todo: inform users to import the package from Deno.land.
+
+## Trying on Deno Deploy
+
+todo: inform users how to try this package on Deno Deploy so they can try before
+committing
+
+### Contributing
+
+View
+[Contribute.md](https://github.com/trophy-place/prizewinner/blob/main/Contribute.md)
+to see how to contribute.

--- a/data/authentication/authenticationManagerNotInitializedErrorMessage.ts
+++ b/data/authentication/authenticationManagerNotInitializedErrorMessage.ts
@@ -1,0 +1,2 @@
+export const authenticationManagerNotInitializedErrorMessage =
+  "Cannot return accessCode because you have never initialized the 'AuthenticationManager'. Please run 'authenticateWithNpsso()' and don't pass the second parameter as 'true' to initialize the 'AuthenticationManager' if you want your authentication to be automatically managed for you.";

--- a/data/authentication/expiredRefreshTokenErrorMessage.ts
+++ b/data/authentication/expiredRefreshTokenErrorMessage.ts
@@ -1,0 +1,2 @@
+export const expiredRefreshTokenErrorMessage =
+  'The "refreshToken" is too old to be refreshed. Please login again using a new NPSSO.';

--- a/services/AuthenticationManager.ts
+++ b/services/AuthenticationManager.ts
@@ -1,4 +1,5 @@
 // Data
+import { authenticationManagerNotInitializedErrorMessage } from "../data/authentication/authenticationManagerNotInitializedErrorMessage.ts";
 import { expiredRefreshTokenErrorMessage } from "../data/authentication/expiredRefreshTokenErrorMessage.ts";
 //
 import { refreshAuthorizationToken } from "../src/authentication/refreshAuthorizationToken.ts";
@@ -8,7 +9,7 @@ import type { AuthenticationData } from "../types/authentication/AuthenticationD
 import { nowTimestamp } from "./nowTimestamp.ts";
 
 /**
- * Automatically manages your authentication status for you, if initialized. To initialize, don't pass `true` as the second parameter of neither `authenticateWithNpsso()` nor `refreshAuthorizationToken()`.
+ * Automatically manages your authentication status for you, if initialized. To initialize, don't pass `true` as the second parameter of `authenticateWithNpsso()`.
  *
  * If initialize, `AuthenticationManager` will be used by all functions to automatically refresh your expired `accessToken` whenever you make a request for data.
  *
@@ -18,8 +19,10 @@ class AuthenticationManager {
   #initialized = false;
   #accessToken = "";
   #tokenExpirationEpoch = 0;
+  #humanReadableTokenExpiration = "";
   #refreshToken = "";
   #refreshTokenExpirationEpoch = 0;
+  #humanReadableRefreshTokenExpiration = "";
 
   /**
    * Gets a valid `accessToken` if you haven't previously disabled the initialization of the `AuthenticationManager`. Throws an error if you never initialized the `AuthenticationManager` or if your `refreshToken` is too old to be refreshed.
@@ -28,9 +31,7 @@ class AuthenticationManager {
    */
   async getAccessCode() {
     if (this.#initialized === false) {
-      throw new Error(
-        "Cannot return token because you have never initialized the AuthenticationManager. Please run 'authenticateWithNpsso()' and don't pass the second parameter as 'true' to initialize the AuthenticationManager if you want your authentication to be automatically managed for you.",
-      );
+      throw new Error(authenticationManagerNotInitializedErrorMessage);
     }
 
     const now = nowTimestamp();
@@ -45,15 +46,40 @@ class AuthenticationManager {
   }
 
   /**
+   * Retrieve the entire Authentication token.
+   *
+   * @returns A `AuthenticationData` object returned by either `refreshAuthorizationToken()` or `authenticateWithNpsso()`.
+   */
+  getFullToken() {
+    if (this.#initialized === false) {
+      throw new Error(authenticationManagerNotInitializedErrorMessage);
+    }
+
+    const token: AuthenticationData = {
+      accessToken: this.#accessToken,
+      tokenExpirationEpoch: this.#tokenExpirationEpoch,
+      humanReadableTokenExpiration: this.#humanReadableTokenExpiration,
+      refreshToken: this.#refreshToken,
+      refreshTokenExpirationEpoch: this.#refreshTokenExpirationEpoch,
+      humanReadableRefreshTokenExpiration:
+        this.#humanReadableRefreshTokenExpiration,
+    };
+    return token;
+  }
+
+  /**
    * Updates the `AuthenticationManager`'s token properties.
    *
-   * @param token An `AuthenticationData` object returned by either `refreshAuthorizationToken()` or `authenticateWithNpsso()`.
+   * @param token A `AuthenticationData` object returned by either `refreshAuthorizationToken()` or `authenticateWithNpsso()`.
    */
   #setToken(token: AuthenticationData) {
     this.#accessToken = token.accessToken;
     this.#tokenExpirationEpoch = token.tokenExpirationEpoch;
+    this.#humanReadableTokenExpiration = token.humanReadableTokenExpiration;
     this.#refreshToken = token.refreshToken;
     this.#refreshTokenExpirationEpoch = token.refreshTokenExpirationEpoch;
+    this.#humanReadableRefreshTokenExpiration =
+      token.humanReadableRefreshTokenExpiration;
   }
 
   /**
@@ -72,7 +98,7 @@ class AuthenticationManager {
   /**
    * Initialize this instance of `AuthenticationManager`.
    *
-   * @param token An `AuthenticationData` object returned by either `refreshAuthorizationToken()` or `authenticateWithNpsso()`.
+   * @param token A `AuthenticationData` object returned by either `refreshAuthorizationToken()` or `authenticateWithNpsso()`.
    */
   initializeToken(token: AuthenticationData) {
     this.#setToken(token);

--- a/services/AuthenticationManager.ts
+++ b/services/AuthenticationManager.ts
@@ -1,0 +1,83 @@
+// Data
+import { expiredRefreshTokenErrorMessage } from "../data/authentication/expiredRefreshTokenErrorMessage.ts";
+//
+import { refreshAuthorizationToken } from "../src/authentication/refreshAuthorizationToken.ts";
+// Types
+import type { AuthenticationData } from "../types/authentication/AuthenticationData_type.ts";
+// Utility functions
+import { nowTimestamp } from "./nowTimestamp.ts";
+
+/**
+ * Automatically manages your authentication status for you, if initialized. To initialize, don't pass `true` as the second parameter of neither `authenticateWithNpsso()` nor `refreshAuthorizationToken()`.
+ *
+ * If initialize, `AuthenticationManager` will be used by all functions to automatically refresh your expired `accessToken` whenever you make a request for data.
+ *
+ * `AuthenticationManager` cannot create a new NPSSO for you, so its maximum lifetime is 60 days, exactly how long `refreshToken` lives for. You will need to authenticate again using a new NPSSO as parameter to `authenticateWithNpsso()` to initialize another `AuthenticationManager`.
+ */
+class AuthenticationManager {
+  #initialized = false;
+  #accessToken = "";
+  #tokenExpirationEpoch = 0;
+  #refreshToken = "";
+  #refreshTokenExpirationEpoch = 0;
+
+  /**
+   * Gets a valid `accessToken` if you haven't previously disabled the initialization of the `AuthenticationManager`. Throws an error if you never initialized the `AuthenticationManager` or if your `refreshToken` is too old to be refreshed.
+   *
+   * @returns `accessToken`
+   */
+  async getAccessCode() {
+    if (this.#initialized === false) {
+      throw new Error(
+        "Cannot return token because you have never initialized the AuthenticationManager. Please run 'authenticateWithNpsso()' and don't pass the second parameter as 'true' to initialize the AuthenticationManager if you want your authentication to be automatically managed for you.",
+      );
+    }
+
+    const now = nowTimestamp();
+
+    if (this.#tokenExpirationEpoch < now) {
+      if (this.#refreshTokenExpirationEpoch < now) {
+        throw new Error(expiredRefreshTokenErrorMessage);
+      }
+      await this.#automaticTokenUpdate();
+    }
+    return this.#accessToken;
+  }
+
+  /**
+   * Updates the `AuthenticationManager`'s token properties.
+   *
+   * @param token An `AuthenticationData` object returned by either `refreshAuthorizationToken()` or `authenticateWithNpsso()`.
+   */
+  #setToken(token: AuthenticationData) {
+    this.#accessToken = token.accessToken;
+    this.#tokenExpirationEpoch = token.tokenExpirationEpoch;
+    this.#refreshToken = token.refreshToken;
+    this.#refreshTokenExpirationEpoch = token.refreshTokenExpirationEpoch;
+  }
+
+  /**
+   * Refreshes the `accessToken` automatically whenever `getAccessCode()` is executed with an expired `accessCode`.
+   */
+  async #automaticTokenUpdate() {
+    const refreshedAuthentication: AuthenticationData =
+      await refreshAuthorizationToken({
+        refreshToken: this.#refreshToken,
+        refreshTokenExpirationEpoch: this.#refreshTokenExpirationEpoch,
+      });
+
+    this.#setToken(refreshedAuthentication);
+  }
+
+  /**
+   * Initialize this instance of `AuthenticationManager`.
+   *
+   * @param token An `AuthenticationData` object returned by either `refreshAuthorizationToken()` or `authenticateWithNpsso()`.
+   */
+  initializeToken(token: AuthenticationData) {
+    this.#setToken(token);
+    this.#initialized = true;
+  }
+}
+
+export const Auth = new AuthenticationManager();

--- a/src/authentication/authenticateWithNpsso.ts
+++ b/src/authentication/authenticateWithNpsso.ts
@@ -6,15 +6,21 @@ import { getAuthorizationToken } from "./getAuthorizationToken.ts";
  * Attempts to authenticate on PSN using a `NPSSO` code and returns your access/refresh tokens if successful.
  *
  * @param npsso The string received when accessing https://ca.account.sony.com/api/v1/ssocookie while logged in with a valid PSN account.
- * @returns `AuthenticationData` object with data required to request further data from other endpoints.
+ * @param disableManager If provided as true, returns an `AuthenticationData` object, but doesn't initialize the `AuthenticationManager`. If not provided, doesn't return anything, but initializes the `AuthenticationManager`.
+ * @returns An `AuthenticationData` object with data required to request further data from other endpoints.
  */
-export async function authenticateWithNpsso(npsso: string) {
+export async function authenticateWithNpsso(
+  npsso: string,
+  disableManager?: true,
+) {
   if (npsso === undefined) {
     throw new Error(
       "No NPSSO was provided, therefore it's impossible to authenticate with PSN. Please provide a NPSSO as the parameter of this function and try again.",
     );
   }
   const accessCode = await getAccessCode(npsso);
-  const authorization = await getAuthorizationToken(accessCode);
-  return authorization;
+  const authorization = await getAuthorizationToken(accessCode, disableManager);
+  if (disableManager === true) {
+    return authorization;
+  }
 }

--- a/src/authentication/getAuthorizationToken.ts
+++ b/src/authentication/getAuthorizationToken.ts
@@ -4,6 +4,7 @@ import {
   AUTHORIZATION_TOKEN_ENDPOINT,
   BASE_URL,
 } from "../../data/base/urls.ts";
+import { Auth } from "../../services/AuthenticationManager.ts";
 // Helper functions
 import { nowTimestamp } from "../../services/nowTimestamp.ts";
 // Types
@@ -14,9 +15,13 @@ import { AuthenticationData } from "../../types/authentication/AuthenticationDat
  * Authenticates on PSN using the `accessCode` and returns your access/refresh tokens if successful.
  *
  * @param accessCode String returned by `getAccessCode()` when providing a valid NPSSO as parameter.
+ * @param disableManager If provided as true, returns a `AuthenticationData`, but doesn't initialize the `AuthenticationManager`. If not provided, doesn't return anything, but initializes the `AuthenticationManager`.
  * @returns `AuthenticationData` object with data required to request further data from other endpoints.
  */
-export async function getAuthorizationToken(accessCode: string) {
+export async function getAuthorizationToken(
+  accessCode: string,
+  disableManager?: true,
+) {
   const authorizationRequestBody = new URLSearchParams({
     "code": accessCode,
     "redirect_uri": "com.scee.psxandroid.scecompcall://redirect",
@@ -58,6 +63,12 @@ export async function getAuthorizationToken(accessCode: string) {
       now + refresh_token_expires_in * 1000,
     ).toISOString(),
   };
+
+  // If the `AuthenticationManager` wasn't disabled, initialize it with the token
+  if (disableManager !== true) {
+    Auth.initializeToken(authentication);
+    return;
+  }
 
   return authentication;
 }

--- a/src/authentication/refreshAuthorizationToken.ts
+++ b/src/authentication/refreshAuthorizationToken.ts
@@ -73,7 +73,7 @@ export async function refreshAuthorizationToken(
   const { access_token, expires_in, refresh_token, refresh_token_expires_in } =
     authenticationResponse;
 
-  const authentication: AuthenticationData = {
+  const authorization: AuthenticationData = {
     accessToken: access_token,
     tokenExpirationEpoch: now + expires_in * 1000,
     humanReadableTokenExpiration: new Date(now + expires_in * 1000)
@@ -85,5 +85,5 @@ export async function refreshAuthorizationToken(
     ).toISOString(),
   };
 
-  return authentication;
+  return authorization;
 }

--- a/src/authentication/refreshAuthorizationToken.ts
+++ b/src/authentication/refreshAuthorizationToken.ts
@@ -1,5 +1,6 @@
 // Data
 import { authorizationHeaders } from "../../data/authentication/authenticationHeaders.ts";
+import { expiredRefreshTokenErrorMessage } from "../../data/authentication/expiredRefreshTokenErrorMessage.ts";
 import {
   AUTHORIZATION_TOKEN_ENDPOINT,
   BASE_URL,
@@ -16,7 +17,12 @@ import type { AuthenticationData } from "../../types/authentication/Authenticati
  * @param token `AuthenticationData` object provided by a successful authentication with `getAuthorizationToken()` or `authenticateWithNpsso()`.
  * @returns A new `AuthenticationData` object with data required to request further data from other endpoints.
  */
-export async function refreshAuthorizationToken(token: AuthenticationData) {
+export async function refreshAuthorizationToken(
+  token: Pick<
+    AuthenticationData,
+    "refreshToken" | "refreshTokenExpirationEpoch"
+  >,
+) {
   // Throw error if invalid parameter or refreshToken was provided
   if (token === undefined || typeof token.refreshToken !== "string") {
     throw new Error(
@@ -35,9 +41,7 @@ export async function refreshAuthorizationToken(token: AuthenticationData) {
 
   // Throw error if the refreshToken timestamp expired
   if (now > token.refreshTokenExpirationEpoch) {
-    throw new Error(
-      'The "refreshToken" is too old to be refreshed. Please login again using a new NPSSO.',
-    );
+    throw new Error(expiredRefreshTokenErrorMessage);
   }
 
   const authorizationRequestBody = new URLSearchParams({

--- a/test.ts
+++ b/test.ts
@@ -1,12 +1,18 @@
+// Test assertion
 import {
   assert,
   assertEquals,
   assertIsError,
   assertNotEquals,
 } from "https://deno.land/std@0.193.0/testing/asserts.ts";
+// Load .env values
 import { load } from "https://deno.land/std@0.193.0/dotenv/mod.ts";
+// Data
+import { expiredRefreshTokenErrorMessage } from "./data/authentication/expiredRefreshTokenErrorMessage.ts";
+// Types
+import type { AuthenticationData } from "./types/authentication/AuthenticationData_type.ts";
+// Internal functions to test
 import { authenticateWithNpsso } from "./src/authentication/authenticateWithNpsso.ts";
-import { AuthenticationData } from "./types/authentication/AuthenticationData_type.ts";
 import { getAccessCode } from "./src/authentication/getAccessCode.ts";
 import { getAuthorizationToken } from "./src/authentication/getAuthorizationToken.ts";
 import { refreshAuthorizationToken } from "./src/authentication/refreshAuthorizationToken.ts";
@@ -188,7 +194,7 @@ Deno.test("Refresh Authentication Token using Refresh Token", async (t) => {
             assertIsError(error);
             assertEquals(
               error.message,
-              'The "refreshToken" is too old to be refreshed. Please login again using a new NPSSO.',
+              expiredRefreshTokenErrorMessage,
             );
           }
         },

--- a/test.ts
+++ b/test.ts
@@ -9,13 +9,13 @@ import {
 import { load } from "https://deno.land/std@0.193.0/dotenv/mod.ts";
 // Data
 import { expiredRefreshTokenErrorMessage } from "./data/authentication/expiredRefreshTokenErrorMessage.ts";
-// Types
-import type { AuthenticationData } from "./types/authentication/AuthenticationData_type.ts";
 // Internal functions to test
 import { authenticateWithNpsso } from "./src/authentication/authenticateWithNpsso.ts";
 import { getAccessCode } from "./src/authentication/getAccessCode.ts";
 import { getAuthorizationToken } from "./src/authentication/getAuthorizationToken.ts";
 import { refreshAuthorizationToken } from "./src/authentication/refreshAuthorizationToken.ts";
+// Authentication Manager Singleton
+import { Auth } from "./services/AuthenticationManager.ts";
 
 let NPSSO: string | undefined;
 if (Deno.env.has("RUNNING_AS_GITHUB_ACTION")) {
@@ -25,7 +25,6 @@ if (NPSSO === undefined) {
   const env = await load();
   NPSSO = env["TEST_NPSSO"];
 }
-let auth: AuthenticationData;
 
 // Tests wether a valid NPSSO is provided and it's possible to authenticate on PSN using it
 Deno.test({ name: "Authenticate using NPSSO" }, async (t) => {
@@ -79,37 +78,38 @@ Deno.test({ name: "Authenticate using NPSSO" }, async (t) => {
     },
   );
 
-  // Test if an authentication attempt returns a valid object with all required properties
+  // Test if an authentication attempt returns a valid `AuthenticationManager` object with all required properties
   await t.step("Authenticate with PSN", async (t) => {
-    const authentication = await authenticateWithNpsso(NPSSO as string);
+    await authenticateWithNpsso(NPSSO as string);
+    const auth = Auth.getFullToken();
+
     await t.step("Authentication has accessToken", () => {
-      assertEquals(typeof authentication.accessToken, "string");
+      assertEquals(typeof auth.accessToken, "string");
     });
     await t.step("Authentication has tokenExpirationEpoch", () => {
-      assertEquals(typeof authentication.tokenExpirationEpoch, "number");
+      assertEquals(typeof auth.tokenExpirationEpoch, "number");
     });
     await t.step("Authentication has humanReadableTokenExpiration", () => {
       assertEquals(
-        typeof authentication.humanReadableTokenExpiration,
+        typeof auth.humanReadableTokenExpiration,
         "string",
       );
     });
     await t.step("Authentication has refreshToken", () => {
-      assertEquals(typeof authentication.refreshToken, "string");
+      assertEquals(typeof auth.refreshToken, "string");
     });
     await t.step("Authentication has tokenExpirationEpoch", () => {
-      assertEquals(typeof authentication.tokenExpirationEpoch, "number");
+      assertEquals(typeof auth.tokenExpirationEpoch, "number");
     });
     await t.step(
       "Authentication has humanReadableRefreshTokenExpiration",
       () => {
         assertEquals(
-          typeof authentication.humanReadableRefreshTokenExpiration,
+          typeof auth.humanReadableRefreshTokenExpiration,
           "string",
         );
       },
     );
-    auth = authentication;
   });
 });
 
@@ -136,6 +136,8 @@ Deno.test("Refresh Authentication Token using Refresh Token", async (t) => {
           }
         },
       );
+
+      const auth = Auth.getFullToken();
 
       // Throws error when token doesn't have a refreshToken field
       await t.step(
@@ -202,6 +204,7 @@ Deno.test("Refresh Authentication Token using Refresh Token", async (t) => {
     },
   );
 
+  const auth = Auth.getFullToken();
   // Test if the token has the correct refreshToken property type
   await t.step("Test if the refreshToken is a string", () => {
     assertEquals(typeof auth.refreshToken, "string");


### PR DESCRIPTION
Users are now able to ignore all the micromanagement of the authentication process, all that is required is not passing `true` as the second argument to `authenticateWithNpsso()`.